### PR TITLE
More intuitive sorting of entities in monster card

### DIFF
--- a/monster-card/README.md
+++ b/monster-card/README.md
@@ -89,3 +89,29 @@ Snow monster card based on random entity state:
     entity: device_tracker.demo_paulus
     state: not_home
 ```
+
+**Sorting entities**
+
+Entities are displayed in the card in the order they are matched by the include filters. I.e. to get a specific order, detailed filters must precede more general ones.
+
+The following example will display `sensor.my_sensor` followed by all other sensors in alphabetical order:
+``` yaml
+- type: custom:monster-card
+  card:
+    type: entities
+  filter:
+    include:
+      - entity_id: sensor.my_sensor
+      - entity_id: sensor.*
+```
+
+The following example will display all sensors in alphabetical order. `sensor.my_sensor` will be included in the sorted list and not be displayed at the end since it has already been matched by `sensor.*`:
+``` yaml
+- type: custom:monster-card
+  card:
+    type: entities
+  filter:
+    include:
+      - entity_id: sensor.*
+      - entity_id: sensor.my_sensor
+```

--- a/monster-card/monster-card.js
+++ b/monster-card/monster-card.js
@@ -38,9 +38,9 @@ class MonsterCard extends HTMLElement {
         filters.push(stateObj => stateObj.state === filter.state);
       }
 
-      Object.values(hass.states).forEach((stateObj) => {
-        if (filters.every(filterFunc => filterFunc(stateObj))) {
-          entities.add(stateObj.entity_id);
+      Object.keys(hass.states).sort().forEach(key => {
+        if (filters.every(filterFunc => filterFunc(hass.states[key]))) {
+          entities.add(hass.states[key].entity_id);
         }
       });
     });
@@ -80,7 +80,6 @@ class MonsterCard extends HTMLElement {
     } else {
       if (config.when && (hass.states[config.when.entity].state == config.when.state) || !config.when) {
         this.style.display = 'block';
-        entities.sort();
       } else {
         this.style.display = 'none';
       }


### PR DESCRIPTION
Don't sort all entities of the card by entity_id, but instead by order in the include filter first, and by entity_id second.

Resolves #23.

---
**Note:**
Entities will be added in the order they are matched. I.e:
```yaml
            filter:
              include:
                - entity_id: sensor.my_sensor
                - entity_id: sensor.*
```

will show `sensor.my_sensor` before all other sensors, while

```yaml
            filter:
              include:
                - entity_id: sensor.*
                - entity_id: sensor.my_sensor
```

will list all sensors in alphabetical order by entity_id