### PR TITLE
Hide measurement if not given

### DIFF
--- a/bignumber-card/bignumber-card.js
+++ b/bignumber-card/bignumber-card.js
@@ -74,7 +74,7 @@ class BigNumberCard extends HTMLElement {
     const config = this._config;
     const root = this.shadowRoot;
     const entityState = hass.states[config.entity].state;
-    const measurement = hass.states[config.entity].attributes.unit_of_measurement;
+    const measurement = hass.states[config.entity].attributes.unit_of_measurement || "";
 
     if (entityState !== this._entityState) {
       root.getElementById("value").textContent = `${entityState} ${measurement}`;


### PR DESCRIPTION
Sometimes states don't have an unit of measurement, e.g IP addresses. Instead of displaying "undefined" we should just display nothing.