### PR TITLE
Avoid errors if horizontal-stack is placed inside vertical-stack-in-card

### DIFF
--- a/vertical-stack-in-card/vertical-stack-in-card.js
+++ b/vertical-stack-in-card/vertical-stack-in-card.js
@@ -35,7 +35,7 @@ class VerticalStackInCard extends HTMLElement {
     config.cards.forEach(item => {
       root.childNodes[index].setConfig(item);
       root.childNodes[index].hass = hass;
-      if (root.childNodes[index].shadowRoot) {
+      if (root.childNodes[index].shadowRoot && root.childNodes[index].shadowRoot.querySelector('ha-card')) {
         root.childNodes[index].shadowRoot.querySelector('ha-card').style.boxShadow = 'none';
         if(index > 0) {
           root.childNodes[index].shadowRoot.querySelector('ha-card').style.paddingTop = '0px';


### PR DESCRIPTION
Title says it all, really. Putting a horizontal-stack inside vertical-stack-in-card gives an error, because horizontal-stack doesn't contain an `ha-card` tag it it's root. This fixes that.

Still doesn't look very good, but at least it doesn't fill the log with errors...