### PR TITLE
Get rid of memory leak

### DIFF
--- a/alarm_control_panel-card/README.md
+++ b/alarm_control_panel-card/README.md
@@ -17,7 +17,7 @@ Alarm control panel card allows you to control [alarm_control_panel](https://www
 | style | string | optional | Allows to override some default styles. Example `--alarm-color-disarmed: var(--label-badge-blue);`
 | auto_enter | object | optional | Options to auto arm and disarm. See `auto_enter` options.
 | labels | object | optional | Labels that augment/override defaults.
-| show_labels | boolean | optional | Show constant that a label is based on. Useful to know label constants when you want to create your own `labels`. Default `true`.
+| show_label_ids | boolean | optional | Allow displaying label constants (when setting to `true`) to be able to map your own translations under `labels`. Defaults to `false`.
 
 `auto_enter` options:
 

--- a/alarm_control_panel-card/README.md
+++ b/alarm_control_panel-card/README.md
@@ -41,10 +41,11 @@ The labels to display. Label name and value. See example.
     - arm_home
     - arm_away
   labels:
-    alarm_code: Inserire un codice a 4 cifre
-    arm_away: Away!!
+    ui.card.alarm_control_panel.code: Inserire un codice a 4 cifre
+    state.alarm_control_panel.arm_away: Away!!
 ```
 
 **Credits**
+- [@gwww](https://github.com/gwww) Added translations
 - [@gwww](https://github.com/gwww) Awesome refactoring
 - [@ciotlosm](https://github.com/ciotlosm)

--- a/alarm_control_panel-card/README.md
+++ b/alarm_control_panel-card/README.md
@@ -16,6 +16,8 @@ Alarm control panel card allows you to control [alarm_control_panel](https://www
 | states | list | optional | A list of possible arm buttons. Supports `arm_home`, `arm_away`, `arm_night`, `arm_custom_bypass`.
 | style | string | optional | Allows to override some default styles. Example `--alarm-color-disarmed: var(--label-badge-blue);`
 | auto_enter | object | optional | Options to auto arm and disarm. See `auto_enter` options.
+| labels | object | optional | Labels that augment/override defaults.
+| show_labels | boolean | optional | Show constant that a label is based on. Useful to know label constants when you want to create your own `labels`. Default `true`.
 
 `auto_enter` options:
 
@@ -23,6 +25,9 @@ Alarm control panel card allows you to control [alarm_control_panel](https://www
 | ---- | ---- | ------- | -----------
 | code_length | integer | Required | When number of digits entered system will arm/disarm
 | arm_action | string | Required | Action to invoke when after digits entered. Can be any of the same values as `states` above.
+
+`labels`:
+The labels to display. Label name and value. See example.
 
 **Example**
 
@@ -35,6 +40,9 @@ Alarm control panel card allows you to control [alarm_control_panel](https://www
   states:
     - arm_home
     - arm_away
+  labels:
+    alarm_code: Inserire un codice a 4 cifre
+    arm_away: Away!!
 ```
 
 **Credits**

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -163,7 +163,8 @@ class AlarmControlPanelCard extends HTMLElement {
 
     const input = root.lastChild.querySelector('paper-input');
     root.querySelectorAll(".pad paper-button").forEach(element => {
-      if (element.getAttribute('value') === 'Clear') {
+      if (element.getAttribute('value') === 
+        this._label("ui.card.alarm_control_panel.clear_code")) {
         element.addEventListener('click', event => {
           input.value = '';
         })
@@ -329,9 +330,10 @@ class AlarmControlPanelCard extends HTMLElement {
   _label(label, default_label=undefined) {
     // Just show "raw" label; useful when want to see underlying const
     // so you can define your own label.
-    if (this._config.show_labels === false) return label;
+    if (this._config.show_label_ids) return label;
 
-    if (this._config.labels[label]) return this._config.labels[label];
+    if (this._config.labels && this._config.labels[label])
+      return this._config.labels[label];
 
     const lang = this.myhass.selectedLanguage || this.myhass.language;
     const translations = this.myhass.resources[lang];

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -39,7 +39,7 @@ class AlarmControlPanelCard extends HTMLElement {
       <ha-icon id="state-icon"></ha-icon>
       ${this._actionButtons()}
       ${entity.attributes.code_format ?
-          `<paper-input label='${this._label("alarm_code")}'
+          `<paper-input label='${this._label("ui.card.alarm_control_panel.code")}'
           type="password"></paper-input>` : ''}
       ${this._keypad(entity)}
     `;
@@ -79,12 +79,13 @@ class AlarmControlPanelCard extends HTMLElement {
     const card = root.lastChild;
     const config = this._config;
 
+    const state_str = "state.alarm_control_panel." + this._state;
     if (config.title) {
       card.header = config.title;
-      root.getElementById("state-text").innerHTML = this._label(this._state);
+      root.getElementById("state-text").innerHTML = this._label(state_str);
       root.getElementById("state-text").className = `state ${this._state}`;
     } else {
-      card.header = this._label(this._state);
+      card.header = this._label(state_str);
     }
 
     root.getElementById("state-icon").setAttribute("icon",
@@ -109,7 +110,7 @@ class AlarmControlPanelCard extends HTMLElement {
 
   _actionButton(state) {
     return `<paper-button noink raised id="${state}">
-      ${this._label(state)}</paper-button>`;
+      ${this._label("ui.card.alarm_control_panel." + state)}</paper-button>`;
   }
 
   _setupActions() {
@@ -208,7 +209,7 @@ class AlarmControlPanelCard extends HTMLElement {
           ${this._keypadButton("3", "DEF")}
           ${this._keypadButton("6", "MNO")}
           ${this._keypadButton("9", "WXYZ")}
-          ${this._keypadButton(this._label("clear"), "")}
+          ${this._keypadButton(this._label("ui.card.alarm_control_panel.clear_code"), "")}
         </div>
       </div>`
   }
@@ -300,6 +301,7 @@ class AlarmControlPanelCard extends HTMLElement {
       .actions {
         margin: 0 8px;
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
         font-size: calc(var(--base-unit) * 1);
       }
@@ -331,13 +333,15 @@ class AlarmControlPanelCard extends HTMLElement {
 
     if (this._config.labels[label]) return this._config.labels[label];
 
-    // Potential way of using loaded translations... (not implemented in core yet)
-    // if (this.myhass.translations[state]) return this.myhass.translations[state];
+    const lang = this.myhass.selectedLanguage || this.myhass.language;
+    const translations = this.myhass.resources[lang];
+    if (translations && translations[label]) return translations[label];
 
     if (default_label) return default_label;
 
-    // If all else fails then pretify the passed in label
-    return label.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
+    // If all else fails then pretify the passed in label const
+    const last_bit = label.split('.').pop();
+    return last_bit.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
   }
 
   getCardSize() {

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -38,8 +38,9 @@ class AlarmControlPanelCard extends HTMLElement {
       ${config.title ? '<div id="state-text"></div>' : ''}
       <ha-icon id="state-icon"></ha-icon>
       ${this._actionButtons()}
-      ${entity.attributes.code_format ? 
-        '<paper-input label="Alarm code" type="password"></paper-input>' : ''}
+      ${entity.attributes.code_format ?
+          `<paper-input label='${this._label("alarm_code")}'
+          type="password"></paper-input>` : ''}
       ${this._keypad(entity)}
     `;
     card.appendChild(this._style(config.style));
@@ -80,10 +81,10 @@ class AlarmControlPanelCard extends HTMLElement {
 
     if (config.title) {
       card.header = config.title;
-      root.getElementById("state-text").innerHTML = this._stateToText(this._state);
+      root.getElementById("state-text").innerHTML = this._label(this._state);
       root.getElementById("state-text").className = `state ${this._state}`;
     } else {
-      card.header = this._stateToText(this._state);
+      card.header = this._label(this._state);
     }
 
     root.getElementById("state-icon").setAttribute("icon",
@@ -108,7 +109,7 @@ class AlarmControlPanelCard extends HTMLElement {
 
   _actionButton(state) {
     return `<paper-button noink raised id="${state}">
-      ${this._stateToText(state)}</paper-button>`;
+      ${this._label(state)}</paper-button>`;
   }
 
   _setupActions() {
@@ -207,7 +208,7 @@ class AlarmControlPanelCard extends HTMLElement {
           ${this._keypadButton("3", "DEF")}
           ${this._keypadButton("6", "MNO")}
           ${this._keypadButton("9", "WXYZ")}
-          ${this._keypadButton("Clear", "")}
+          ${this._keypadButton(this._label("clear"), "")}
         </div>
       </div>`
   }
@@ -323,10 +324,20 @@ class AlarmControlPanelCard extends HTMLElement {
     return style;
   }
 
-  _stateToText(state) {
-    if (this._config.labels[state]) return this._config.labels[state];
+  _label(label, default_label=undefined) {
+    // Just show "raw" label; useful when want to see underlying const
+    // so you can define your own label.
+    if (this._config.show_labels === false) return label;
+
+    if (this._config.labels[label]) return this._config.labels[label];
+
+    // Potential way of using loaded translations... (not implemented in core yet)
     // if (this.myhass.translations[state]) return this.myhass.translations[state];
-    return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
+
+    if (default_label) return default_label;
+
+    // If all else fails then pretify the passed in label
+    return label.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
   }
 
   getCardSize() {

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -1,5 +1,6 @@
 class AlarmControlPanelCard extends HTMLElement {
   constructor() {
+    console.log("AlarmControlPanelCard constructor");
     super();
     this.attachShadow({ mode: 'open' });
     this._icons = {
@@ -16,6 +17,7 @@ class AlarmControlPanelCard extends HTMLElement {
   set hass(hass) {
     const entity = hass.states[this._config.entity];
 
+    console.log("set hass");
     if (entity) {
       this.myhass = hass;
       if(!this.shadowRoot.lastChild) {
@@ -51,7 +53,20 @@ class AlarmControlPanelCard extends HTMLElement {
     this._setupActions();
   }
 
+  connectedCallback() {
+    console.log("connectedCallback");
+  }
+
+  disconnectedCallback() {
+    console.log("disconnectedCallback");
+  }
+
+  attributeChangedCallback(attrName, oldVal, newVal) {
+    console.log("attrChanged: ", attrName, oldVal, newVal);
+  }
+
   setConfig(config) {
+    console.log("setConfig");
     if (!config.entity || config.entity.split(".")[0] !== "alarm_control_panel") {
       throw new Error('Please specify an entity from alarm_control_panel domain.');
     }
@@ -88,20 +103,17 @@ class AlarmControlPanelCard extends HTMLElement {
     root.getElementById("state-icon").className = this._state;
 
     const armVisible = (this._state === 'disarmed');
-    Array.from(root.getElementById("actions").children).forEach(function(item) {
-      if (armVisible) {
-        item.style.display = (item.id === "disarm") ? 'none' : "";
-      } else {
-        item.style.display = (item.id === "disarm") ? "" : "none";
-      }
-    });
+    root.getElementById("arm-actions").style.display = armVisible ? "" : "none";
+    root.getElementById("disarm-actions").style.display = armVisible ? "none" : "";
   }
 
   _actionButtons() {
     const armVisible = (this._state === 'disarmed');
     return `
-      <div id="actions" class="actions">
+      <div id="arm-actions" class="actions">
         ${this._config.states.map(el => `${this._actionButton(el)}`).join('')}
+      </div>
+      <div id="disarm-actions" class="actions">
         ${this._actionButton('disarm')}
       </div>`;
   }
@@ -324,6 +336,8 @@ class AlarmControlPanelCard extends HTMLElement {
   }
 
   _stateToText(state) {
+    if (this._config.labels[state]) return this._config.labels[state];
+    // if (this.myhass.translations[state]) return this.myhass.translations[state];
     return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
   }
 

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -1,6 +1,5 @@
 class AlarmControlPanelCard extends HTMLElement {
   constructor() {
-    console.log("AlarmControlPanelCard constructor");
     super();
     this.attachShadow({ mode: 'open' });
     this._icons = {
@@ -17,7 +16,6 @@ class AlarmControlPanelCard extends HTMLElement {
   set hass(hass) {
     const entity = hass.states[this._config.entity];
 
-    console.log("set hass");
     if (entity) {
       this.myhass = hass;
       if(!this.shadowRoot.lastChild) {
@@ -54,19 +52,9 @@ class AlarmControlPanelCard extends HTMLElement {
   }
 
   connectedCallback() {
-    console.log("connectedCallback");
-  }
-
-  disconnectedCallback() {
-    console.log("disconnectedCallback");
-  }
-
-  attributeChangedCallback(attrName, oldVal, newVal) {
-    console.log("attrChanged: ", attrName, oldVal, newVal);
   }
 
   setConfig(config) {
-    console.log("setConfig");
     if (!config.entity || config.entity.split(".")[0] !== "alarm_control_panel") {
       throw new Error('Please specify an entity from alarm_control_panel domain.');
     }

--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -2,21 +2,6 @@ class AlarmControlPanelCard extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    this._stateStrings = {
-      'arm_away': 'Arm away',
-      'arm_custom_bypass': 'Custom',
-      'arm_home': 'Arm home',
-      'arming': 'Arming',
-      'arm_night': 'Arm night',
-      'armed_away': 'Armed away',
-      'armed_custom_bypass': 'Armed custom',
-      'armed_home': 'Armed home',
-      'armed_night': 'Armed night',
-      'disarm': 'Disarm',
-      'disarmed': 'Disarmed',
-      'pending': 'Pending',
-      'triggered': 'Triggered',
-    }
     this._icons = {
       'armed_away': 'mdi:security-lock',
       'armed_custom_bypass': 'mdi:security',
@@ -29,12 +14,41 @@ class AlarmControlPanelCard extends HTMLElement {
   }
 
   set hass(hass) {
-    this.myhass = hass;
     const entity = hass.states[this._config.entity];
-    if (entity && entity.state != this._state) {
-      this._state = entity.state;
-      this._updateCardContent(entity);
+
+    if (entity) {
+      this.myhass = hass;
+      if(!this.shadowRoot.lastChild) {
+        this._createCard(entity);
+      }
+      if (entity.state != this._state) {
+        this._state = entity.state;
+        this._updateCardContent(entity);
+      }
     }
+  }
+
+  _createCard(entity) {
+    const config = this._config;
+
+    const card = document.createElement('ha-card');
+    const content = document.createElement('div');
+    content.id = "content";
+    content.innerHTML = `
+      ${config.title ? '<div id="state-text"></div>' : ''}
+      <ha-icon id="state-icon"></ha-icon>
+      ${this._actionButtons()}
+      ${entity.attributes.code_format ? 
+        '<paper-input label="Alarm code" type="password"></paper-input>' : ''}
+      ${this._keypad(entity)}
+    `;
+    card.appendChild(this._style(config.style));
+    card.appendChild(content);
+    this.shadowRoot.appendChild(card);
+
+    this._setupInput();
+    this._setupKeypad();
+    this._setupActions();
   }
 
   setConfig(config) {
@@ -48,20 +62,12 @@ class AlarmControlPanelCard extends HTMLElement {
       }
       this._arm_action = config.auto_enter.arm_action;
     }
+    if (!config.states) config.states = ['arm_away', 'arm_home'];
+    if (!config.scale) config.scale = '15px';
+    this._config = Object.assign({}, config);
 
     const root = this.shadowRoot;
     if (root.lastChild) root.removeChild(root.lastChild);
-    if (!config.states) config.states = ['arm_home', 'arm_away'];
-    if (!config.scale) config.scale = '15px';
-
-    this._card = document.createElement('ha-card');
-    const content = document.createElement('div');
-    content.id = "content";
-    this._config = Object.assign({}, config);
-    this._card.appendChild(this._style(config.style));
-    this._card.appendChild(content);
-    root.appendChild(this._card);
-    this._config = Object.assign({}, config);
   }
 
   _updateCardContent(entity) {
@@ -69,49 +75,43 @@ class AlarmControlPanelCard extends HTMLElement {
     const card = root.lastChild;
     const config = this._config;
 
-    if (!config.title) {
-      card.header = this._stateToText(this._state);
-    } else {
+    if (config.title) {
       card.header = config.title;
+      root.getElementById("state-text").innerHTML = this._stateToText(this._state);
+      root.getElementById("state-text").className = `state ${this._state}`;
+    } else {
+      card.header = this._stateToText(this._state);
     }
 
-    root.getElementById("content").innerHTML = `
-      ${this._icon()}
-      ${config.title ? `<div class='state ${this._state}'>
-        ${this._stateToText(this._state)}</div>` : ''}
-      ${this._actionButtons()}
-      ${entity.attributes.code_format ? '<paper-input label="Alarm code" type="password"></paper-input>' : ''}
-      ${this._keypad(entity)}
-    `;
+    root.getElementById("state-icon").setAttribute("icon",
+      this._icons[this._state] || 'mdi:shield-outline');
+    root.getElementById("state-icon").className = this._state;
 
-    this._setupActions();
-    this._setupInput();
-    this._setupKeypad();
-  }
-
-  _icon() {
-    return `<ha-icon icon='${this._stateToIcon(this._state)}'
-      class='${this._state}'></ha-icon>`
+    const armVisible = (this._state === 'disarmed');
+    Array.from(root.getElementById("actions").children).forEach(function(item) {
+      if (armVisible) {
+        item.style.display = (item.id === "disarm") ? 'none' : "";
+      } else {
+        item.style.display = (item.id === "disarm") ? "" : "none";
+      }
+    });
   }
 
   _actionButtons() {
     const armVisible = (this._state === 'disarmed');
     return `
-      <div class="actions">
-        ${armVisible
-        ? `${this._config.states.map(el => `${this._actionButton(el)}`).join('')}`
-        : `${this._actionButton('disarm')}`}
-      </div>`
+      <div id="actions" class="actions">
+        ${this._config.states.map(el => `${this._actionButton(el)}`).join('')}
+        ${this._actionButton('disarm')}
+      </div>`;
   }
 
   _actionButton(state) {
-    return `<paper-button noink raised id="${state}">${this._stateToText(state)}
-      </paper-button>`;
+    return `<paper-button noink raised id="${state}">
+      ${this._stateToText(state)}</paper-button>`;
   }
 
   _setupActions() {
-    // TODO: fix memory leak for reattaching handlers every time
-    // Need a way to avoid doing innerHTML, at least without detaching handlers first
     const card = this.shadowRoot.lastChild;
     const config = this._config;
 
@@ -323,12 +323,8 @@ class AlarmControlPanelCard extends HTMLElement {
     return style;
   }
 
-  _stateToIcon(state) {
-    return this._icons[state] || 'mdi:shield-outline'
-  }
-
   _stateToText(state) {
-    return this._stateStrings[state] || 'Unknown'
+    return state.split('_').join(' ').replace(/^\w/, c => c.toUpperCase());
   }
 
   getCardSize() {


### PR DESCRIPTION
Well, primarily this was to get rid of the memory leak that you commented in the code. I also wanted to play around to see what other ways I might structure the code. 

So, the major change is to how the card is built/updated on `set hass` calls. The `setConfig` calls really focus only on config except for one line to delete the old card on config changes.

I also changed the `stateToText`. Simplified by programatically computing the button text rather than using the mapping array. This also has the benefit that alarm panels that have other arming modes than the standard ones will work. For example the panel I'm working on creating support for (ElkM1) has an arm vacation.

I've done some testing. Everything I tried works. However the change is rather significant so more testing by others would be helpful. Hey, it beta software :)