### PR TITLE
feat: add support for custom units

### DIFF
--- a/entity-attributes-card/entity-attributes-card.js
+++ b/entity-attributes-card/entity-attributes-card.js
@@ -33,7 +33,7 @@ class EntityAttributesCard extends HTMLElement {
           if (filters.every(filterFunc => filterFunc(`${key}.${attr_key}`))) {
             attributes.set(`${key}.${attr_key}`, {
               name: `${filter.name?filter.name:attr_key.replace(/_/g, ' ')}`,
-              value: hass.states[key].attributes[attr_key],
+              value: `${hass.states[key].attributes[attr_key]} ${filter.unit||''}`.trim(),
             });
           }  
         });


### PR DESCRIPTION
This commit adds a new `unit` attribute you can define to show a custom string (unit) near the value.

![image](https://user-images.githubusercontent.com/5382443/44923553-e40b5a80-ad48-11e8-8fab-311733820d00.png)