### PR TITLE
Let buttons wrap around when there are too many.

### DIFF
--- a/alarm_control_panel-card/alarm_control_panel-card.js
+++ b/alarm_control_panel-card/alarm_control_panel-card.js
@@ -299,6 +299,7 @@ class AlarmControlPanelCard extends HTMLElement {
       .actions {
         margin: 0 8px;
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
         font-size: calc(var(--base-unit) * 1);
       }


### PR DESCRIPTION
If there are more than two action buttons, they can be cut off by the edge of the panel.  Add flex-wrap to allow the action buttons to wrap around to a new line.