### PR TITLE
Add support for idle and toggling

### DIFF
--- a/thermostat-card/thermostat-card.js
+++ b/thermostat-card/thermostat-card.js
@@ -77,7 +77,12 @@ class ThermostatCard extends HTMLElement {
     if (!cardConfig.chevron_size) cardConfig.chevron_size = 50;
     if (!cardConfig.num_ticks) cardConfig.num_ticks = 150;
     if (!cardConfig.tick_degrees) cardConfig.tick_degrees = 300;
-    if (!cardConfig.hvac.states) cardConfig.hvac.states = { 'off': 'off', 'heat': 'heat', 'cool': 'cool', };
+    if (!cardConfig.hvac.states) cardConfig.hvac.states = {
+      'off': 'off',
+      'idle': 'idle',
+      'heat': 'heat',
+      'cool': 'cool'
+    };
 
     // Extra config values generated for simplicity of updates
     cardConfig.radius = cardConfig.diameter / 2;

--- a/thermostat-card/thermostat-card.js
+++ b/thermostat-card/thermostat-card.js
@@ -55,6 +55,12 @@ class ThermostatCard extends HTMLElement {
     }
   }
 
+  _controlToggle() {
+    this._hass.callService('climate', (this.thermostat.hvac_state == 'off') ? 'turn_on' : 'turn_off', {
+      entity_id: this._config.entity
+    });
+  }
+
   setConfig(config) {
     // Check config
     if (!config.entity && config.entity.split(".")[0] === 'climate') {
@@ -90,6 +96,7 @@ class ThermostatCard extends HTMLElement {
     cardConfig.ticks_inner_radius = cardConfig.diameter / 8;
     cardConfig.offset_degrees = 180 - (360 - cardConfig.tick_degrees) / 2;
     cardConfig.control = this._controlSetPoints.bind(this);
+    cardConfig.toggle = this._controlToggle.bind(this);
     this.thermostat = new ThermostatUI(cardConfig);
 
     if (cardConfig.no_card === true) {

--- a/thermostat-card/thermostat-card.lib.js
+++ b/thermostat-card/thermostat-card.lib.js
@@ -64,6 +64,7 @@ export default class ThermostatUI {
     this._root = root;
     this._buildControls(config.radius);
     this._root.addEventListener('click', () => this._enableControls());
+    this._root.addEventListener('contextmenu', () => this._toggle());
   }
 
   updateState(options) {
@@ -253,6 +254,12 @@ export default class ThermostatUI {
       this._updateClass('in_control', this.in_control);
       config.control();
     }, config.pending * 1000);
+  }
+
+  _toggle() {
+    const config = this._config;
+    config.toggle();
+    return false;
   }
 
   _updateClass(class_name, flag) {

--- a/thermostat-card/thermostat-card.lib.js
+++ b/thermostat-card/thermostat-card.lib.js
@@ -473,6 +473,7 @@ export default class ThermostatUI {
         user-select: none;
       
         --thermostat-off-fill: #222;
+        --thermostat-idle-fill: #555;
         --thermostat-path-color: rgba(255, 255, 255, 0.3);
         --thermostat-heat-fill: #E36304;
         --thermostat-cool-fill: #007AF1;
@@ -527,6 +528,9 @@ export default class ThermostatUI {
       }
       .dial--state--off .dial__shape {
         fill: var(--thermostat-off-fill);
+      }
+      .dial--state--idle .dial__shape {
+        fill: var(--thermostat-idle-fill);
       }
       .dial--state--heat .dial__shape {
         fill: var(--thermostat-heat-fill);


### PR DESCRIPTION
1. Added support for an idle state (grayed out, but not black; indicates that the thermostat is working, but the heater/AC engine is off, waiting for the temperature to fall/rise).

2. Added support for toggling the thermostat via the context menu (long press on touchscreen devices). Not the most elegant solution (since it works differently across platforms), but for phones/tablets, it's a very convenient feature.