### PR TITLE
catch errors if thermostat entity does not exist

### DIFF
--- a/thermostat-card/thermostat-card.js
+++ b/thermostat-card/thermostat-card.js
@@ -7,6 +7,12 @@ class ThermostatCard extends HTMLElement {
   set hass(hass) {
     const config = this._config;
     const entity = hass.states[config.entity];
+    if(entity === undefined) {
+      const new_state = { connected: false }
+      if (!this._saved_state || this._saved_state.connected != new_state.connected)
+        this.thermostat.updateState(new_state);
+      return;
+    }
     let ambient_temperature = entity.attributes.current_temperature;
     if (config.ambient_temperature && hass.states[config.ambient_temperature])
       ambient_temperature = hass.states[config.ambient_temperature].state;
@@ -24,6 +30,7 @@ class ThermostatCard extends HTMLElement {
       target_temperature_high: entity.attributes.target_temp_high,
       hvac_state: config.hvac.states[hvac_state] || 'off',
       away: (entity.attributes.away_mode == 'on' ? true : false),
+      connected: true
     }
     if (!this._saved_state ||
       (this._saved_state.min_value != new_state.min_value ||
@@ -33,7 +40,8 @@ class ThermostatCard extends HTMLElement {
         this._saved_state.target_temperature_low != new_state.target_temperature_low ||
         this._saved_state.target_temperature_high != new_state.target_temperature_high ||
         this._saved_state.hvac_state != new_state.hvac_state ||
-        this._saved_state.away != new_state.away)) {
+        this._saved_state.away != new_state.away ||
+        this._saved_state.connected != new_state.connected)) {
       this._saved_state = new_state;
       this.thermostat.updateState(new_state);
     }

--- a/thermostat-card/thermostat-card.lib.js
+++ b/thermostat-card/thermostat-card.lib.js
@@ -67,6 +67,10 @@ export default class ThermostatUI {
   }
 
   updateState(options) {
+    this._updateConnected(options.connected)
+    if(!options.connected)
+      return;
+
     const config = this._config;
     const away = options.away || false;
     this.min_value = options.min_value;
@@ -326,6 +330,14 @@ export default class ThermostatUI {
     });
   }
 
+  _updateConnected(connected) {
+    this._updateClass('disabled', !connected)
+    if(!connected) {
+      this._root.querySelector(`#ambient`).querySelectorAll('tspan')[0].textContent = 'Error';
+      this._root.querySelector(`#target`).querySelectorAll('tspan')[0].textContent = 'Error';
+    }
+  }
+
   _buildCore(diameter) {
     return SvgUtil.createSVGElement('svg', {
       width: '100%',
@@ -476,6 +488,7 @@ export default class ThermostatUI {
         --thermostat-path-color: rgba(255, 255, 255, 0.3);
         --thermostat-heat-fill: #E36304;
         --thermostat-cool-fill: #007AF1;
+        --thermostat-disabled-fill: #72787e;
         --thermostat-path-active-color: rgba(255, 255, 255, 0.8);
         --thermostat-path-active-color-large: rgba(255, 255, 255, 1);
         --thermostat-text-color: white;
@@ -608,6 +621,13 @@ export default class ThermostatUI {
       .dial__lbl--ring {
         font-size: 22px;
         font-weight: bold;
+      }
+      .dial.disabled .dial__shape {
+        fill: var(--thermostat-disabled-fill);
+      }
+      .dial.disabled .dial__lbl--ambient, .dial.disabled .dial__lbl--target {
+        font-weight: normal;
+        font-size: 60px;
       }`
   }
 }


### PR DESCRIPTION
Catches and updates if entity can not be found. Current style when disconnected:
![image](https://user-images.githubusercontent.com/1080613/47272889-e5dbe800-d559-11e8-8625-23123340fbd8.png)


I'm not attached to the style. I would be willing to remove any of the changes to the style, but I thought it would be good to show something rather than nothing.

The backstory on this is that my thermostat component didn't connect the other day, and when that happened, my lovelace views would not load due to an exception.