### PR TITLE
groups filter added

### DIFF
--- a/monster-card/monster-card.js
+++ b/monster-card/monster-card.js
@@ -1,7 +1,7 @@
 class MonsterCard extends HTMLElement {
 
   _getEntities(hass, filters) {
-    function _filterEntityId(stateObj, pattern) {
+	function _filterEntityId(stateObj, pattern) {
       if (pattern.indexOf('*') === -1) {
         return stateObj.entity_id === pattern;
       }
@@ -39,6 +39,10 @@ class MonsterCard extends HTMLElement {
     const entities = new Map();
     filters.forEach((filter) => {
       const filters = [];
+	  if (filter.group) {
+		const entities = hass.states[filter.group].attributes['entity_id'];
+		filters.push(stateObj => entities.includes(stateObj.entity_id));
+	  }
       if (filter.domain) {
         filters.push(stateObj => stateObj.entity_id.split('.', 1)[0] === filter.domain);
       }

--- a/monster-card/monster-card.js
+++ b/monster-card/monster-card.js
@@ -40,8 +40,10 @@ class MonsterCard extends HTMLElement {
     filters.forEach((filter) => {
       const filters = [];
 	  if (filter.group) {
-		const entities = hass.states[filter.group].attributes['entity_id'];
-		filters.push(stateObj => entities.includes(stateObj.entity_id));
+		if (filter.group in hass.states){
+			const entities = hass.states[filter.group].attributes['entity_id'];
+			filters.push(stateObj => entities.includes(stateObj.entity_id));
+		}
 	  }
       if (filter.domain) {
         filters.push(stateObj => stateObj.entity_id.split('.', 1)[0] === filter.domain);


### PR DESCRIPTION
adds filtering by automation group in monster-card. E.g.

type: 'custom:monster-card'
show_empty: false
card:
  type: glance
  title: Water leak
filter:
  include:
    - group: group.water_leak
  exclude:
    - state: 'off'