### PR TITLE
Updated card to work with v0.88

### DIFF
--- a/gauge-card/gauge-card.js
+++ b/gauge-card/gauge-card.js
@@ -21,7 +21,7 @@ class GaugeCard extends HTMLElement {
     if (entityParts.attribute) cardConfig.attribute = entityParts.attribute;
 
     const card = document.createElement('ha-card');
-    const shadow = card.attachShadow({ mode: 'open' });
+//     const shadow = card.attachShadow({ mode: 'open' });
     const content = document.createElement('div');
     const style = document.createElement('style');
     style.textContent = `


### PR DESCRIPTION
Remove the shadow reference.  This fixes the "attachShadow" error when trying to use this card in v0.88