### PR TITLE
CI: Auto-release, Node 24, badges, funding, v2.0.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [ciotlosm]
+buy_me_a_coffee: gUEVWJc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - master
-      - redesign
   pull_request:
     branches:
       - master
@@ -23,6 +19,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
 
       - name: Build
         run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,24 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - '.hass_dev/**'
 
 jobs:
   release:
-    name: Build & Publish Release
+    name: Build & Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -24,16 +31,29 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Upload release asset
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/thermostat-dark-card.js
-          asset_name: thermostat-dark-card.js
-          tag: ${{ github.ref }}
-          overwrite: true
-
       - name: HACS Validation
         uses: hacs/action@main
         with:
           category: plugin
+
+      - name: Get version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: dist/thermostat-dark-card.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,19 +17,19 @@ The `master` branch is protected. All changes must go through pull requests.
 
 ## Release Process
 
-Merging to master does NOT create a release. Releases are manual:
+Releases are automatic. When a PR is merged to master:
 
 ```
-1. Merge your PR to master
-2. Go to GitHub → Releases → Create a new release
-3. Create a new tag (e.g. v2.0.0) targeting master
-4. Publish the release
-5. release.yml triggers automatically:
-   - Builds the card
-   - Uploads thermostat-dark-card.js as a release asset
-   - Runs HACS validation
-6. HACS users see the new version and can update
+1. release.yml triggers automatically
+2. It builds the card and runs HACS validation
+3. It reads the version from package.json
+4. If that version tag doesn't exist yet, it creates a GitHub Release
+5. The built JS file is uploaded as a release asset
+6. HACS users see the new version
 ```
+
+To trigger a new release, bump the version in `package.json` as part of your PR.
+If the version in `package.json` already has a corresponding tag, no release is created.
 
 ## How HACS Installs
 
@@ -44,8 +44,8 @@ HACS uses the following to discover and install the card:
 
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
-| `build.yml` | Push to master/redesign, PRs to master | Build + HACS validation |
-| `release.yml` | Published GitHub Release | Build + upload JS to release assets |
+| `build.yml` | PRs to master | Type check + Build + HACS validation |
+| `release.yml` | Push to master (merged PR) | Build + HACS validation + auto-release if version bumped |
 
 ## For AI Agents
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+## Branch & PR Workflow
+
+The `master` branch is protected. All changes must go through pull requests.
+
+```
+1. Create a feature branch from master
+2. Push the branch to origin
+3. Create a PR targeting master
+4. CI (build.yml) runs automatically on the PR
+5. Review and merge the PR
+6. CI runs again on the merge commit to master
+```
+
+**Never push directly to master.**
+
+## Release Process
+
+Merging to master does NOT create a release. Releases are manual:
+
+```
+1. Merge your PR to master
+2. Go to GitHub → Releases → Create a new release
+3. Create a new tag (e.g. v2.0.0) targeting master
+4. Publish the release
+5. release.yml triggers automatically:
+   - Builds the card
+   - Uploads thermostat-dark-card.js as a release asset
+   - Runs HACS validation
+6. HACS users see the new version and can update
+```
+
+## How HACS Installs
+
+HACS uses the following to discover and install the card:
+
+- **Discovery**: `hacs.json` defines the card category (`plugin`) and filename
+- **Version**: HACS looks at GitHub Releases (tags) for available versions
+- **Download**: HACS downloads `thermostat-dark-card.js` from the release assets
+- **README**: `render_readme: true` in `hacs.json` means HACS shows the README content in the store listing
+
+## CI Workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| `build.yml` | Push to master/redesign, PRs to master | Build + HACS validation |
+| `release.yml` | Published GitHub Release | Build + upload JS to release assets |
+
+## For AI Agents
+
+If you are an AI agent contributing to this repo:
+
+1. **Never push to master directly** — always create a branch and PR
+2. **Use `git push -u origin <branch-name>`** for new branches
+3. **Use `gh pr create`** to open PRs (use `--body-file` for complex descriptions)
+4. **Do not create releases** — that's a manual step by the maintainer
+5. **Run `npx tsc --noEmit` and `npm run build`** before committing to verify no errors
+6. **Commit messages**: Use conventional style — short title, detailed body if needed
+
+## Development Setup
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for local dev environment setup.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Thermostat Dark Card
 
+[![HACS Default](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
+[![GitHub Release](https://img.shields.io/github/v/release/ciotlosm/lovelace-thermostat-dark-card?style=for-the-badge)](https://github.com/ciotlosm/lovelace-thermostat-dark-card/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/ciotlosm/lovelace-thermostat-dark-card/release.yml?style=for-the-badge)](https://github.com/ciotlosm/lovelace-thermostat-dark-card/actions)
+[![License](https://img.shields.io/github/license/ciotlosm/lovelace-thermostat-dark-card?style=for-the-badge)](LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/ciotlosm/lovelace-thermostat-dark-card/total?style=for-the-badge)](https://github.com/ciotlosm/lovelace-thermostat-dark-card/releases)
+
 A Nest-style thermostat card for Home Assistant with a round dial interface. Supports single and dual (heat/cool) setpoints, preset modes, and multiple themes.
 
 <!-- Add screenshot: place your preview image at docs/preview.png -->
@@ -158,3 +164,10 @@ ambient_temperature: sensor.living_room_external_temp
 ## License
 
 MIT
+---
+
+## Support
+
+If you find this card useful, consider buying me a coffee:
+
+<a href="https://www.buymeacoffee.com/gUEVWJc" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" height="40"></a>

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
-  "name": "Dark Thermostat",
+  "name": "Thermostat Dark Card",
   "render_readme": true,
-  "filename": "thermostat-dark-card.js"
+  "filename": "thermostat-dark-card.js",
+  "homeassistant": "2024.1.0",
+  "content_in_root": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thermostat-dark-card",
   "type": "module",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A thermostat card with a round dial for Home Assistant — supports dark and light themes",
   "keywords": [
     "home-assistant",

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,4 @@
-export const CARD_VERSION = '1.0.0';
+export const CARD_VERSION = '2.0.0';
 
 export const DEFAULT_CONFIG = {
   pending: 3,


### PR DESCRIPTION
## Changes

- **Auto-release**: Merging to master now auto-creates a GitHub Release when package.json version is bumped. No manual release creation needed.
- **CI**: build.yml runs on PRs only (type check + build + HACS). release.yml handles master pushes.
- **Node 24**: Upgraded actions/setup-node v4 to v6 to eliminate Node 20 deprecation warnings.
- **Badges**: HACS Default, GitHub Release, Build status, License, Downloads
- **Funding**: Restored Buy Me a Coffee link and GitHub FUNDING.yml
- **hacs.json**: Added minimum HA version requirement
- **Version**: Bumped to v2.0.0 for the first redesign release
- **CONTRIBUTING.md**: Documents the full workflow for contributors and AI agents

## Release flow after merge

Once this merges, the release workflow will:
1. Build the JS
2. See version 2.0.0 has no tag
3. Create release v2.0.0 with auto-generated notes
4. Upload thermostat-dark-card.js as release asset
5. HACS users can then install/update
