### PR TITLE
Auto versioning with label-based bumps

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,56 @@
+name: Auto Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Suggest version label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const filePaths = files.map(f => f.filename);
+
+            // Major: breaking changes (types.ts interface changes, major refactors)
+            const isMajor = filePaths.some(f => f === 'src/types.ts') &&
+              files.some(f => f.filename === 'src/types.ts' && f.patch && f.patch.includes('-'));
+
+            // Minor: new features (new files, new config options)
+            const isMinor = files.some(f => f.status === 'added' && f.filename.startsWith('src/'));
+
+            // Default: patch
+            let label = 'patch';
+            if (isMajor) label = 'major';
+            else if (isMinor) label = 'minor';
+
+            // Only add if no version label exists
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const hasVersionLabel = labels.some(l => ['major', 'minor', 'patch'].includes(l.name));
+            if (!hasVersionLabel) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label],
+              });
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,15 @@
 name: Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - master
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
-      - '.hass_dev/**'
 
 jobs:
   release:
     name: Build & Release
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,6 +17,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v6
         with:
@@ -28,6 +27,33 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine version bump
+        id: bump
+        run: |
+          LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          if echo "$LABELS" | grep -qi "major"; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -qi "minor"; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        id: version
+        run: |
+          npm version ${{ steps.bump.outputs.type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${{ steps.version.outputs.version }}"
+          git push
+
       - name: Build
         run: npm run build
 
@@ -36,21 +62,7 @@ jobs:
         with:
           category: plugin
 
-      - name: Get version from package.json
-        id: version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Check if tag exists
-        id: tag_check
-        run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create Release
-        if: steps.tag_check.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,22 @@ HACS uses the following to discover and install the card:
 | Workflow | Trigger | What it does |
 |----------|---------|-------------|
 | `build.yml` | PRs to master | Type check + Build + HACS validation |
-| `release.yml` | Push to master (merged PR) | Build + HACS validation + auto-release if version bumped |
+| `label.yml` | PR opened/updated | Auto-suggests version label (patch/minor/major) |
+| `release.yml` | PR merged to master | Bumps version, builds, creates GitHub Release |
+
+## Versioning
+
+Version is managed **only** in `package.json`. It's injected at build time via Vite — no need to update `src/const.ts`.
+
+Version bumps happen automatically on PR merge based on labels:
+
+| Label | When to use | Example |
+|-------|------------|---------|
+| `patch` (default) | Bug fixes, tweaks, docs | Fix rounding, adjust position |
+| `minor` | New features, new config options | Add readonly mode, new theme |
+| `major` | Breaking changes | Config format change, removed options |
+
+The `label.yml` workflow auto-suggests a label based on file changes, but you can override it manually.
 
 ## For AI Agents
 
@@ -54,9 +69,14 @@ If you are an AI agent contributing to this repo:
 1. **Never push to master directly** — always create a branch and PR
 2. **Use `git push -u origin <branch-name>`** for new branches
 3. **Use `gh pr create`** to open PRs (use `--body-file` for complex descriptions)
-4. **Do not create releases** — that's a manual step by the maintainer
-5. **Run `npx tsc --noEmit` and `npm run build`** before committing to verify no errors
-6. **Commit messages**: Use conventional style — short title, detailed body if needed
+4. **Apply version labels** to your PRs:
+   - `patch` — bug fixes, small tweaks (default if no label)
+   - `minor` — new features, new options
+   - `major` — breaking changes to config or behavior
+5. **Do not bump version manually** — the release workflow handles it
+6. **Do not create releases** — they're automatic on PR merge
+7. **Run `npx tsc --noEmit` and `npm run build`** before committing to verify no errors
+8. **Commit messages**: Use conventional style — short title, detailed body if needed
 
 ## Development Setup
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,5 @@
-export const CARD_VERSION = '2.0.0';
+declare const __CARD_VERSION__: string;
+export const CARD_VERSION = __CARD_VERSION__;
 
 export const DEFAULT_CONFIG = {
   pending: 3,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
+  define: {
+    __CARD_VERSION__: JSON.stringify(pkg.version),
+  },
   build: {
     target: 'es2017',
     minify: 'terser',


### PR DESCRIPTION
## Auto Versioning

Single source of truth for version: `package.json` only.

### How it works

1. PR is opened → `label.yml` auto-suggests a version label (patch/minor/major)
2. PR is merged → `release.yml` bumps version based on label, builds, creates release
3. HACS picks up the new release

### Labels

- **patch** (default): bug fixes, tweaks
- **minor**: new features, new config options  
- **major**: breaking changes

### Changes

- Version injected at build time via Vite `define` — no more `const CARD_VERSION = 'x.x.x'` to maintain
- `release.yml` triggers on PR merge (not push), bumps version, commits, tags, releases
- `label.yml` auto-labels PRs based on file changes
- CONTRIBUTING.md updated with versioning docs for contributors and AI agents
