### PR TITLE
chore: dependabot uses conventional commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
-  # Check npm dependencies for security updates
+  # Check npm dependencies for version updates
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     labels:
       - "patch"
 
@@ -15,5 +18,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     labels:
       - "patch"


### PR DESCRIPTION
## What

Add `commit-message.prefix: "chore"` and `commit-message.include: "scope"`
to both the `npm` and `github-actions` entries in
`.github/dependabot.yml`. Dependabot fully supports this config
(it has been part of the Dependabot v2 schema since launch).

Also fix the misleading comment on the npm entry: Dependabot's
`weekly` schedule covers version updates, not just security updates.

## Effect

Future Dependabot PRs will be titled:

- `chore(deps): bump X from Y to Z` (npm)
- `chore(github-actions): bump action-name from X to Y` (github-actions)

instead of the current `Bump X from Y to Z` (which is not
conventional-commit format and trips up release-please's parser).

## Why this matters

The `Bump X` title format was the root cause of the silent
release-please failure that PR #360 (manual 2.6.1 release) had
to work around. See the release-please logs from the post-#360
Release workflow run:

```
commit could not be parsed: acb918d Bump prettier from 3.9.4 to 3.9.5 (#352)
error message: Error: unexpected token ' ' at 1:5, valid tokens [(, !, :]
... (12 Dependabot commits rejected) ...
No user facing commits found since a62c48a... - skipping
```

12 of the 14 PRs merged between 2.6.0 and 2.6.1 were Dependabot
bumps. All 12 were rejected as unparseable, leaving only the
`chore:` ones (#359, #360) for release-please to consider. None
of those triggered a release, so release-please concluded "skip".

## Scope of this PR

This PR fixes the parser issue only. It does **not** make
Dependabot merges auto-release. Per the project's CONTRIBUTING.md,
`chore:` commits don't trigger a version bump:

| Prefix     | Bump   |
|------------|--------|
| `fix:`     | patch  |
| `feat:`    | minor  |
| `feat!:`   | major  |
| `chore:`   | none   |
| `docs:`    | none   |

So Dependabot bumps remain no-bump (correct: dev-only changes
shouldn't ship a card release to HACS users). The next time
release-please runs, however, it will see the Dependabot commits
as `chore:`, parse them correctly, and only consider real
`fix:` / `feat:` commits when deciding whether to open a Release
PR. That fixes the broken state from #360.

## If you want Dependabot merges to auto-release

That would require a more invasive change: drop the `chore`
prefix and use per-update-type prefixes (`fix(deps):` for patch,
`feat(deps):` for minor, `feat(deps)!:` for major). Dependabot's
`commit-message.prefix` is a single string, not per-update-type,
so this would need either multiple `updates` entries with
`ignore` filters (fragile) or a custom action. Out of scope for
this PR -- flag if you want it.

## Verification

- Schema-wise: `commit-message` and `include` are documented
  Dependabot options, present in the v2 schema
- Behavior-wise: cannot be verified until the next Dependabot
  weekly run (next check is on the configured interval)
- release-please behavior: will be verifiable on the next
  Release workflow run after a `fix:` or `feat:` PR lands
